### PR TITLE
Question on index for finite approx

### DIFF
--- a/Week_11/tutorial_notes.md
+++ b/Week_11/tutorial_notes.md
@@ -41,11 +41,11 @@ Following this through to our finite difference approximations, we can see that
 $$
 \begin{gather}
 \frac{\partial u}{\partial x}
-\approx \frac{u_{i,j+1} - u_{i,j-1}}{\Delta x}
-= \frac{u_{s+1} - u_{s-1}}{\Delta x}
+\approx \frac{u_{i+1,j} - u_{i-1,j}}{\Delta x}
+= \frac{u_{s+1} - u_{s-1}}{\2*Delta x}
 \\
 \frac{\partial u}{\partial y}
-\approx \frac{u_{i+1,j} - u_{i-1,j}}{\Delta y}
+\approx \frac{u_{i,j+1} - u_{i,j-1}}{\2*Delta y}
 = \frac{u_{s+w} - u_{s-w}}{\Delta y}
 \end{gather}
 $$


### PR DESCRIPTION
Hey Alex, 
Wasn't sure how to pull a request on ICT notes to ask questions, hoping this works. 

2 questions on the finite differences: 

Why is the delta x one changing j instead of i? It was originally i during the W11 ICT but then you realised it was a mistake and changed it to j for your fixing index in your commit. 

I thought the x-axis was associated with the row which is indexed with i & the y-axis uses j? Why does it switch? 

Q1: Since it's a central difference finite differences formula, is the numerator of the finite difference 2*delta(x) or 2*delta(y)